### PR TITLE
Fix lua error when connecting

### DIFF
--- a/lua/effects/gib_spray/init.lua
+++ b/lua/effects/gib_spray/init.lua
@@ -21,7 +21,7 @@ function EFFECT:Think()
 	if ( self.Delay > CurTime() ) then return true end
 	self.Delay = CurTime() + 0.05
 	
-	if ( !IsValid( self.Parent ) ) then
+	if ( !IsValid( self.Parent ) or !IsValid(self.PhysBone) ) then
 		return false
 	end
 	


### PR DESCRIPTION
I think it'll fix 
```
[ERROR] addons/gibmod/lua/effects/gib_spray/init.lua:29: Tried to use a NULL physics object!
  1. GetAngles - [C]:-1
   2. unknown - addons/gibmod/lua/effects/gib_spray/init.lua:29
```
which occurs when you connect to the server sometimes. Haven't tested yet though.